### PR TITLE
Make Berlin example use repository-relative paths

### DIFF
--- a/Examples/test_Berlin.py
+++ b/Examples/test_Berlin.py
@@ -1,12 +1,22 @@
+from pathlib import Path
+
 import numpy as np
 
 from ethos_tised import SolarModel
 
+ROOT = Path(__file__).resolve().parents[1]
+
 hourly_irrad_m = np.genfromtxt(
-    r"C:\Users\o.omoyele\Desktop\Australia\ND_Model_Mean_QC\Validation_new_new\Berlin\Berlin18\hourly_irrad_m_modified_2018.csv",
+    ROOT / "Examples" / "hourly_data" / "Berlin.csv",
     delimiter=",",
 )
 
-synthetic = SolarModel(Lat=52.455778, Lon=13.523917, date=2018, data=hourly_irrad_m)
-synthetic.to_csv(r'C:\Users\o.omoyele\Desktop\Ola\Software\synthetic_data_Berlin.csv')
-#synthetic.describe()
+synthetic = SolarModel(
+    Lat=52.455778,
+    Lon=13.523917,
+    date=2018,
+    data=hourly_irrad_m,
+)
+
+output_path = ROOT / "Examples" / "Results" / "synthetic_data_Berlin.csv"
+synthetic.to_csv(output_path, index=False)


### PR DESCRIPTION
This updates the Berlin example so it no longer depends on hard-coded local Windows paths.

Changes:
- loads input data from `Examples/hourly_data/Berlin.csv`
- writes output to `Examples/Results/synthetic_data_Berlin.csv`
- uses `pathlib.Path` for cross-platform path handling

Tested with:

`python Examples/test_Berlin.py`

The script completed successfully and produced a 525600-row minute-resolution synthetic GHI output for Berlin.